### PR TITLE
auto-claude: 002-automated-link-checking

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -5,7 +5,7 @@
 max_concurrency = 10
 
 # Accept these HTTP status codes as valid
-accept = [200, 204, 206, 301, 302, 307, 308, 429]
+accept = [200, 204, 206, 301, 302, 307, 308, 403, 429]
 
 # Timeout for each request (in seconds)
 timeout = 20

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,12 +60,13 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1
         with:
-          args: --verbose --no-progress --accept 200,403,429 'build/**/*.html'
+          args: --config .github/lychee.toml --verbose --no-progress 'build/**/*.html'
+          fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   deploy:
-    needs: build
+    needs: [build, check-links]
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Add automated link validation to the CI/CD pipeline that checks all internal and external links for validity. Broken links should fail the build to prevent 404 errors from reaching users.